### PR TITLE
Canonical kw detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,24 @@ This python package allows you to automate tests to check if a keyword is censor
 
 <img src="screenshot.png" alt="screenshot" style="width: 700px;"/>
 
+# IMPORTANT: Upgrading from v0.1 with an existing database? 
+The database table has been modified to accomodate tracking of minimum keyword strings triggering 
+censorship. If you used blockedonweibo v0.1 and you used a database to store results, you will 
+need to update your database file. 
+
+**To migrate your older database file**
+1. Move `update_db.py` to the same file directory as your database file ("results.sqlite" if you followed
+this setup guide)
+2. In terminal, run `python update_db.py` and confirm database file. 
+
+### Version 0.2 changes 
+* now includes a feature to find canonical censored keywords (minimum set of keywords required to trigger explicit censorship message)
+    * to run, pass `get_canonical=True` with rest of variables into `run()`
+    * see tktk
+
+
 # Table of Contents
- <p><div class="lev1 toc-item"><a href="#What-is-blockedonweibo?" data-toc-modified-id="What-is-blockedonweibo?-1"><span class="toc-item-num">1&nbsp;&nbsp;</span>What is blockedonweibo?</a></div><div class="lev1 toc-item"><a href="#Install-the-blockedonweibo-package" data-toc-modified-id="Install-the-blockedonweibo-package-2"><span class="toc-item-num">2&nbsp;&nbsp;</span>Install the blockedonweibo package</a></div><div class="lev1 toc-item"><a href="#Adjust-your-settings" data-toc-modified-id="Adjust-your-settings-3"><span class="toc-item-num">3&nbsp;&nbsp;</span>Adjust your settings</a></div><div class="lev1 toc-item"><a href="#Let's-start-testing!" data-toc-modified-id="Let's-start-testing!-4"><span class="toc-item-num">4&nbsp;&nbsp;</span>Let's start testing!</a></div><div class="lev2 toc-item"><a href="#Pass-a-dictionary-of-keywords-to-start-testing" data-toc-modified-id="Pass-a-dictionary-of-keywords-to-start-testing-41"><span class="toc-item-num">4.1&nbsp;&nbsp;</span>Pass a dictionary of keywords to start testing</a></div><div class="lev2 toc-item"><a href="#Pass-in-cookies-so-you-can-also-get-the-number-of-results.-Pass-in-sqlite_file-to-save-the-results-to-disk-so-you-can-load-it-later" data-toc-modified-id="Pass-in-cookies-so-you-can-also-get-the-number-of-results.-Pass-in-sqlite_file-to-save-the-results-to-disk-so-you-can-load-it-later-42"><span class="toc-item-num">4.2&nbsp;&nbsp;</span>Pass in cookies so you can also get the number of results. Pass in sqlite_file to save the results to disk so you can load it later</a></div><div class="lev2 toc-item"><a href="#If-your-test-gets-interrupted-or-you-add-more-keywords,-you-can-pick-up-where-you-left-off" data-toc-modified-id="If-your-test-gets-interrupted-or-you-add-more-keywords,-you-can-pick-up-where-you-left-off-43"><span class="toc-item-num">4.3&nbsp;&nbsp;</span>If your test gets interrupted or you add more keywords, you can pick up where you left off</a></div><div class="lev2 toc-item"><a href="#You-can-attach-notes-or-categorizations-to-your-keywords-for-easy-querying-and-analysis-later" data-toc-modified-id="You-can-attach-notes-or-categorizations-to-your-keywords-for-easy-querying-and-analysis-later-44"><span class="toc-item-num">4.4&nbsp;&nbsp;</span>You can attach notes or categorizations to your keywords for easy querying and analysis later</a></div><div class="lev2 toc-item"><a href="#If-you-want-to-test-multiple-times-a-day,-just-pass-in-the-test_number-param" data-toc-modified-id="If-you-want-to-test-multiple-times-a-day,-just-pass-in-the-test_number-param-45"><span class="toc-item-num">4.5&nbsp;&nbsp;</span>If you want to test multiple times a day, just pass in the <code>test_number</code> param</a></div><div class="lev2 toc-item"><a href="#It-can-skip-redundant-keywords" data-toc-modified-id="It-can-skip-redundant-keywords-46"><span class="toc-item-num">4.6&nbsp;&nbsp;</span>It can skip redundant keywords</a></div><div class="lev2 toc-item"><a href="#You-can-also-pass-in-lists-if-you-prefer-(though-you-can't-include-the-source-or-notes)" data-toc-modified-id="You-can-also-pass-in-lists-if-you-prefer-(though-you-can't-include-the-source-or-notes)-47"><span class="toc-item-num">4.7&nbsp;&nbsp;</span>You can also pass in lists if you prefer (though you can't include the source or notes)</a></div>
+ <p><div class="lev1 toc-item"><a href="#What-is-blockedonweibo?" data-toc-modified-id="What-is-blockedonweibo?-1"><span class="toc-item-num">1&nbsp;&nbsp;</span>What is blockedonweibo?</a></div><div class="lev1 toc-item"><a href="#Install-the-blockedonweibo-package" data-toc-modified-id="Install-the-blockedonweibo-package-2"><span class="toc-item-num">2&nbsp;&nbsp;</span>Install the blockedonweibo package</a></div><div class="lev1 toc-item"><a href="#Adjust-your-settings" data-toc-modified-id="Adjust-your-settings-3"><span class="toc-item-num">3&nbsp;&nbsp;</span>Adjust your settings</a></div><div class="lev1 toc-item"><a href="#Let's-start-testing!" data-toc-modified-id="Let's-start-testing!-4"><span class="toc-item-num">4&nbsp;&nbsp;</span>Let's start testing!</a></div><div class="lev2 toc-item"><a href="#Pass-a-dictionary-of-keywords-to-start-testing" data-toc-modified-id="Pass-a-dictionary-of-keywords-to-start-testing-41"><span class="toc-item-num">4.1&nbsp;&nbsp;</span>Pass a dictionary of keywords to start testing</a></div><div class="lev2 toc-item"><a href="#Pass-in-cookies-so-you-can-also-get-the-number-of-results.-Pass-in-sqlite_file-to-save-the-results-to-disk-so-you-can-load-it-later" data-toc-modified-id="Pass-in-cookies-so-you-can-also-get-the-number-of-results.-Pass-in-sqlite_file-to-save-the-results-to-disk-so-you-can-load-it-later-42"><span class="toc-item-num">4.2&nbsp;&nbsp;</span>Pass in cookies so you can also get the number of results. Pass in sqlite_file to save the results to disk so you can load it later</a></div><div class="lev2 toc-item"><a href="#If-your-test-gets-interrupted-or-you-add-more-keywords,-you-can-pick-up-where-you-left-off" data-toc-modified-id="If-your-test-gets-interrupted-or-you-add-more-keywords,-you-can-pick-up-where-you-left-off-43"><span class="toc-item-num">4.3&nbsp;&nbsp;</span>If your test gets interrupted or you add more keywords, you can pick up where you left off</a></div><div class="lev2 toc-item"><a href="#You-can-attach-notes-or-categorizations-to-your-keywords-for-easy-querying-and-analysis-later" data-toc-modified-id="You-can-attach-notes-or-categorizations-to-your-keywords-for-easy-querying-and-analysis-later-44"><span class="toc-item-num">4.4&nbsp;&nbsp;</span>You can attach notes or categorizations to your keywords for easy querying and analysis later</a></div><div class="lev2 toc-item"><a href="#If-you-want-to-test-multiple-times-a-day,-just-pass-in-the-test_number-param" data-toc-modified-id="If-you-want-to-test-multiple-times-a-day,-just-pass-in-the-test_number-param-45"><span class="toc-item-num">4.5&nbsp;&nbsp;</span>If you want to test multiple times a day, just pass in the <code>test_number</code> param</a></div><div class="lev2 toc-item"><a href="#It-can-skip-redundant-keywords" data-toc-modified-id="It-can-skip-redundant-keywords-46"><span class="toc-item-num">4.6&nbsp;&nbsp;</span>It can skip redundant keywords</a></div><div class="lev2 toc-item"><a href="#You-can-also-pass-in-lists-if-you-prefer-(though-you-can't-include-the-source-or-notes)" data-toc-modified-id="You-can-also-pass-in-lists-if-you-prefer-(though-you-can't-include-the-source-or-notes)-47"><span class="toc-item-num">4.7&nbsp;&nbsp;</span>You can also pass in lists if you prefer (though you can't include the source or notes)</a></div><div class="lev2 toc-item"><a href="#It-can-detect-the-canonical-(minimum)-set-of-characters-in-the-search-query-triggering-censorship" data-toc-modified-id="It-can-detect-the-canonical-(minimum)-set-of-characters-in-the-search-query-triggering-censorship-48"><span class="toc-item-num">4.8&nbsp;&nbsp;</span>It can detect the canonical (minimum) set of characters in the search query triggering censorship</a></div>
 
 # Install the blockedonweibo package
 
@@ -241,8 +257,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -258,8 +276,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -273,8 +293,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -288,8 +310,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -383,8 +407,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -400,8 +426,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -415,8 +443,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -430,8 +460,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -445,8 +477,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -562,8 +596,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -579,8 +615,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -594,8 +632,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -609,8 +649,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -624,8 +666,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -639,8 +683,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>5705260.0</td>
       <td>pop culture</td>
     </tr>
@@ -654,8 +700,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>881.0</td>
       <td>pop culture</td>
     </tr>
@@ -669,8 +717,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>63401495.0</td>
       <td>social media</td>
     </tr>
@@ -702,8 +752,10 @@ results.query("notes=='pop culture'")
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -719,8 +771,10 @@ results.query("notes=='pop culture'")
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>5705260.0</td>
       <td>pop culture</td>
     </tr>
@@ -734,8 +788,10 @@ results.query("notes=='pop culture'")
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>881.0</td>
       <td>pop culture</td>
     </tr>
@@ -787,8 +843,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -804,8 +862,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -819,8 +879,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -834,8 +896,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -849,8 +913,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -864,8 +930,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>5705260.0</td>
       <td>pop culture</td>
     </tr>
@@ -879,8 +947,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>881.0</td>
       <td>pop culture</td>
     </tr>
@@ -894,8 +964,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>63401495.0</td>
       <td>social media</td>
     </tr>
@@ -909,8 +981,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454634.0</td>
       <td>None</td>
     </tr>
@@ -924,8 +998,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -939,8 +1015,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -954,8 +1032,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1049,8 +1129,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -1066,8 +1148,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -1081,8 +1165,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1096,8 +1182,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1111,8 +1199,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1126,8 +1216,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>5705260.0</td>
       <td>pop culture</td>
     </tr>
@@ -1141,8 +1233,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>881.0</td>
       <td>pop culture</td>
     </tr>
@@ -1156,8 +1250,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>63401495.0</td>
       <td>social media</td>
     </tr>
@@ -1171,8 +1267,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454634.0</td>
       <td>None</td>
     </tr>
@@ -1186,8 +1284,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1201,8 +1301,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1216,8 +1318,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1231,8 +1335,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe2</td>
+      <td>None</td>
       <td>109.0</td>
       <td>location</td>
     </tr>
@@ -1246,15 +1352,16 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe2</td>
+      <td>None</td>
       <td>648313.0</td>
       <td>pop culture</td>
     </tr>
   </tbody>
 </table>
 </div>
-
 
 
 ## You can also pass in lists if you prefer (though you can't include the source or notes)
@@ -1300,8 +1407,10 @@ weibo.sqlite_to_df(sqlite_file)
       <th>censored</th>
       <th>no_results</th>
       <th>reset</th>
+      <th>is_canonical</th>
       <th>result</th>
       <th>source</th>
+      <th>orig_keyword</th>
       <th>num_results</th>
       <th>notes</th>
     </tr>
@@ -1317,8 +1426,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454701.0</td>
       <td>None</td>
     </tr>
@@ -1332,8 +1443,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1347,8 +1460,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1362,8 +1477,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1377,8 +1494,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>5705260.0</td>
       <td>pop culture</td>
     </tr>
@@ -1392,8 +1511,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>881.0</td>
       <td>pop culture</td>
     </tr>
@@ -1407,8 +1528,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>63401495.0</td>
       <td>social media</td>
     </tr>
@@ -1422,8 +1545,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>80454634.0</td>
       <td>None</td>
     </tr>
@@ -1437,8 +1562,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1452,8 +1579,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1467,8 +1596,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>my dataframe</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1482,8 +1613,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe2</td>
+      <td>None</td>
       <td>109.0</td>
       <td>location</td>
     </tr>
@@ -1497,8 +1630,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>my dataframe2</td>
+      <td>None</td>
       <td>648313.0</td>
       <td>pop culture</td>
     </tr>
@@ -1512,8 +1647,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>list</td>
+      <td>None</td>
       <td>648313.0</td>
       <td>None</td>
     </tr>
@@ -1527,8 +1664,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>has_results</td>
       <td>list</td>
+      <td>None</td>
       <td>28413048.0</td>
       <td>None</td>
     </tr>
@@ -1542,8 +1681,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>reset</td>
       <td>list</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1557,8 +1698,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>censored</td>
       <td>list</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1572,8 +1715,10 @@ weibo.sqlite_to_df(sqlite_file)
       <td>0</td>
       <td>0</td>
       <td>0</td>
+      <td>0</td>
       <td>no_results</td>
       <td>list</td>
+      <td>None</td>
       <td>NaN</td>
       <td>None</td>
     </tr>
@@ -1582,8 +1727,421 @@ weibo.sqlite_to_df(sqlite_file)
 </div>
 
 
+## It can detect the canonical (minimum) set of characters in the search query triggering censorship
 
+Set `get_canonical=True` when running to find which part of a censored search query is actually triggering the censorship. Note: this will only work on explicitly censored search queries.
+
+Finding canonical censored keywords can take a large number of search cycles, especially with larger original queries. 
 
 ```python
-
+weibo.run(['江蛤','江泽民江蛤蟆'],sqlite_file=sqlite_file,cookies=cookie,continue_interruptions=False,get_canonical=True)
 ```
+
+If we find a minimum keyword component, we'll record it as a keyword, set column `is_canonical` to True, and record our full search query in `orig_keyword`. For completeness, we'll also include the original keyword as its own entry with `is_canonical=False`
+
+```python
+weibo.sqlite_to_df(sqlite_file)
+```
+
+
+<div>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>id</th>
+      <th>date</th>
+      <th>datetime_logged</th>
+      <th>test_number</th>
+      <th>keyword</th>
+      <th>censored</th>
+      <th>no_results</th>
+      <th>reset</th>
+      <th>is_canonical</th>
+      <th>result</th>
+      <th>source</th>
+      <th>orig_keyword</th>
+      <th>num_results</th>
+      <th>notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:13:37.816720</td>
+      <td>1</td>
+      <td>hello</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>80454701.0</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:13:54.356722</td>
+      <td>1</td>
+      <td>lxb</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:14:11.489530</td>
+      <td>1</td>
+      <td>习胞子</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>no_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:14:29.667395</td>
+      <td>1</td>
+      <td>刘晓波</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:14:49.107078</td>
+      <td>1</td>
+      <td>pokemon</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>5705260.0</td>
+      <td>pop culture</td>
+    </tr>
+    <tr>
+      <th>5</th>
+      <td>5</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:15:09.762484</td>
+      <td>1</td>
+      <td>jay chou</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>881.0</td>
+      <td>pop culture</td>
+    </tr>
+    <tr>
+      <th>6</th>
+      <td>6</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:15:28.100418</td>
+      <td>1</td>
+      <td>weibo</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>63401495.0</td>
+      <td>social media</td>
+    </tr>
+    <tr>
+      <th>7</th>
+      <td>7</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:15:46.214464</td>
+      <td>2</td>
+      <td>hello</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>80454634.0</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>8</th>
+      <td>8</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:16:03.274804</td>
+      <td>2</td>
+      <td>lxb</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>9</th>
+      <td>9</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:16:19.035805</td>
+      <td>2</td>
+      <td>习胞子</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>no_results</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>10</th>
+      <td>10</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:16:36.021837</td>
+      <td>2</td>
+      <td>刘晓波</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>my dataframe</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>11</th>
+      <td>11</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:16:53.766351</td>
+      <td>1</td>
+      <td>zhongnanhai</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe2</td>
+      <td>None</td>
+      <td>109.0</td>
+      <td>location</td>
+    </tr>
+    <tr>
+      <th>12</th>
+      <td>12</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:17:14.124440</td>
+      <td>1</td>
+      <td>cats</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>my dataframe2</td>
+      <td>None</td>
+      <td>648313.0</td>
+      <td>pop culture</td>
+    </tr>
+    <tr>
+      <th>13</th>
+      <td>13</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:17:36.205255</td>
+      <td>1</td>
+      <td>cats</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>list</td>
+      <td>None</td>
+      <td>648313.0</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>14</th>
+      <td>14</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:17:54.330039</td>
+      <td>1</td>
+      <td>yes</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>has_results</td>
+      <td>list</td>
+      <td>None</td>
+      <td>28413048.0</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>15</th>
+      <td>15</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:19:47.007930</td>
+      <td>1</td>
+      <td>自由亚洲电台</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>reset</td>
+      <td>list</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>16</th>
+      <td>16</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:20:03.491231</td>
+      <td>1</td>
+      <td>刘晓波</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>list</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>17</th>
+      <td>17</td>
+      <td>2017-09-25</td>
+      <td>2017-09-25 10:20:18.747414</td>
+      <td>1</td>
+      <td>dhfjkdashfjkasdsf87</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>no_results</td>
+      <td>list</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+     <tr>
+      <th>18</th>
+      <td>18</td>
+      <td>2017-11-15</td>
+      <td>2017-11-15 12:38:32.931313</td>
+      <td>1</td>
+      <td>江蛤</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>1</td>
+      <td>censored</td>
+      <td>list</td>
+      <td>江蛤</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>19</th>
+      <td>19</td>
+      <td>2017-11-15</td>
+      <td>2017-11-15 12:38:32.963135</td>
+      <td>1</td>
+      <td>江蛤</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>list</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>20</th>
+      <td>20</td>
+      <td>2017-11-15</td>
+      <td>2017-11-15 12:40:21.294841</td>
+      <td>1</td>
+      <td>江蛤</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>1</td>
+      <td>censored</td>
+      <td>list</td>
+      <td>江泽民江蛤蟆</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <th>21</th>
+      <td>21</td>
+      <td>2017-11-15</td>
+      <td>2017-11-15 12:40:21.326378</td>
+      <td>1</td>
+      <td>江泽民江蛤蟆</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td>censored</td>
+      <td>list</td>
+      <td>None</td>
+      <td>NaN</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+     

--- a/README.md
+++ b/README.md
@@ -180,8 +180,10 @@ weibo.run(sample_keywords_df,insert=False,return_df=True)
       <th></th>
       <th>date</th>
       <th>datetime</th>
+      <th>is_canonical</th>
       <th>keyword</th>
       <th>num_results</th>
+      <th>orig_keyword</th>
       <th>result</th>
       <th>source</th>
       <th>test_number</th>
@@ -192,8 +194,10 @@ weibo.run(sample_keywords_df,insert=False,return_df=True)
       <th>0</th>
       <td>2017-09-25</td>
       <td>2017-09-25 10:12:45.280812</td>
+      <td>False</td>
       <td>hello</td>
       <td>[]</td>
+      <td>None</td>
       <td>has_results</td>
       <td>my dataframe</td>
       <td>1</td>
@@ -202,7 +206,9 @@ weibo.run(sample_keywords_df,insert=False,return_df=True)
       <th>0</th>
       <td>2017-09-25</td>
       <td>2017-09-25 10:13:00.191900</td>
+      <td>False</td>
       <td>lxb</td>
+      <td>None</td>
       <td>None</td>
       <td>censored</td>
       <td>my dataframe</td>
@@ -212,7 +218,9 @@ weibo.run(sample_keywords_df,insert=False,return_df=True)
       <th>0</th>
       <td>2017-09-25</td>
       <td>2017-09-25 10:13:16.356805</td>
+      <td>False</td>
       <td>习胞子</td>
+      <td>None</td>
       <td>None</td>
       <td>no_results</td>
       <td>my dataframe</td>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ this setup guide)
 ### Version 0.2 changes 
 * now includes a feature to find canonical censored keywords (minimum set of keywords required to trigger explicit censorship message)
     * to run, pass `get_canonical=True` with rest of variables into `run()`
-    * see tktk
+    * see section 4.8
 
 
 # Table of Contents

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -344,8 +344,8 @@ def run(keywords,
                 for i in range(len(test_list)):
                     if verbose=="all":
                         print("Testing %d of %d: omitting character %s" %(i+1, len(test_list), kw[i]))
-                    if sleep_recursive:
-                        time.sleep(random.randint(math.ceil(sleep * .90), math.ceil(sleep * 1.10)))
+                    if sleep:
+                        time.sleep(random.randint(math.ceil(sleep_secs * .90), math.ceil(sleep_secs * 1.10)))
                     if has_censorship(test_list[i], cookies)[0] != "censored":
                         min_str += (kw[i])
                 result_min_str, num_results_min_str = has_censorship(min_str, cookies)
@@ -386,7 +386,7 @@ def run(keywords,
         return results_df
 
 
-def split_search_query(query, cookies, sleep=0, res_rtn=[], known_blocked=False):
+def split_search_query(query, cookies, sleep_secs=0, res_rtn=[], known_blocked=False):
     """
     Recursively halves a query and returns portions with blocked keywords as a list of strings.
     :param res_rtn: internal list holding found min keywords during recursive search, DO NOT SPECIFY.
@@ -395,16 +395,16 @@ def split_search_query(query, cookies, sleep=0, res_rtn=[], known_blocked=False)
     """
     if len(query) <= 1:
         return [-1]
-    if sleep:
-        time.sleep(random.randint(math.ceil(sleep * .90), math.ceil(sleep * 1.10)))
+    if sleep_secs:
+        time.sleep(random.randint(math.ceil(sleep_secs * .90), math.ceil(sleep_secs * 1.10)))
     if (not known_blocked) and has_censorship(query, cookies)[0] != "censored":  # known_blocked=True skips 1st check
         return [-1]
     else:
         mid = len(query) // 2
         left_half = query[:mid]
         right_half = query[mid:]
-        left_res = split_search_query(left_half, cookies, sleep, res_rtn, known_blocked=False)
-        right_res = split_search_query(right_half, cookies, sleep, res_rtn, known_blocked=False)
+        left_res = split_search_query(left_half, cookies, sleep_secs, res_rtn, known_blocked=False)
+        right_res = split_search_query(right_half, cookies, sleep_secs, res_rtn, known_blocked=False)
         if (left_res[0] == -1) and (right_res[0] == -1):
             res_rtn.append(query)
     return res_rtn

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -329,6 +329,7 @@ def run(keywords,
         elif verbose=="some" and (count%10==0 or count==0):
             print(r.Index,keyword_encoded, result)
 
+        min_str = None
         if get_canonical and result == "censored":
             if verbose=="some" or verbose=="all":
                 print("Found censored search phrase; determining canonical censored keyword set")

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -332,8 +332,8 @@ def run(keywords,
         if get_canonical and result == "censored":
             if verbose=="some" or verbose=="all":
                 print("Found censored search phrase; determining canonical censored keyword set")
-
-            potential_kws = split_search_query(keyword_encoded, cookies, res_rtn=[], known_blocked=True)
+            sleep_recursive = sleep_secs if sleep is True else 0
+            potential_kws = split_search_query(keyword_encoded, cookies, sleep_recursive, res_rtn=[], known_blocked=True)
             if verbose=="all":
                 print(potential_kws)
 
@@ -343,6 +343,8 @@ def run(keywords,
                 for i in range(len(test_list)):
                     if verbose=="all":
                         print("Testing %d of %d: omitting character %s" %(i+1, len(test_list), kw[i]))
+                    if sleep_recursive:
+                        time.sleep(random.randint(math.ceil(sleep * .90), math.ceil(sleep * 1.10)))
                     if has_censorship(test_list[i], cookies)[0] != "censored":
                         min_str += (kw[i])
                 result_min_str, num_results_min_str = has_censorship(min_str, cookies)
@@ -383,19 +385,21 @@ def run(keywords,
         return results_df
 
 
-def split_search_query(query, cookies, res_rtn=[], known_blocked=False):
+def split_search_query(query, cookies, sleep=0, res_rtn=[], known_blocked=False):
     """Recursively halves a query and returns portions with blocked keywords as a list of strings.
     """
     if len(query) <= 1:
         return [-1]
+    if sleep:
+        time.sleep(random.randint(math.ceil(sleep * .90), math.ceil(sleep * 1.10)))
     if (not known_blocked) and has_censorship(query, cookies)[0] != "censored":  # known_blocked=True skips 1st check
         return [-1]
     else:
         mid = len(query) // 2
         left_half = query[:mid]
         right_half = query[mid:]
-        left_res = split_search_query(left_half, cookies, res_rtn, known_blocked=False)
-        right_res = split_search_query(right_half, cookies, res_rtn, known_blocked=False)
+        left_res = split_search_query(left_half, cookies, sleep, res_rtn, known_blocked=False)
+        right_res = split_search_query(right_half, cookies, sleep, res_rtn, known_blocked=False)
         if (left_res[0] == -1) and (right_res[0] == -1):
             res_rtn.append(query)
     return res_rtn

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -110,9 +110,6 @@ def user_login(username=weibo_credentials.Creds().username,
 def has_censorship(keyword_encoded,
                 cookies=None):
 
-    ##DEBUG
-    print("testing" + keyword_encoded.encode('utf-8'))
-
     """
     Function which actually looks up whether a search for the given keyword returns text
     which is displayed during censorship.
@@ -149,13 +146,10 @@ def has_censorship(keyword_encoded,
         None
     
     if CENSORSHIP_PHRASE_DECODED in r:
-        print("censored") ##DEBUG
         return ("censored",None)
     elif NO_RESULTS_PHRASE_DECODED in r:
-        print("no-results")  ##DEBUG
         return ("no_results",None)
     else:
-        print("has-results")  ##DEBUG
         return ("has_results",num_results)
 
 def create_database(sqlite_file, overwrite=False):
@@ -340,7 +334,8 @@ def run(keywords,
                 print("Found censored search phrase; determining canonical censored keyword set")
 
             potential_kws = split_search_query(keyword_encoded, cookies, res_rtn=[], known_blocked=True)
-            print(potential_kws)
+            if verbose=="all":
+                print(potential_kws)
 
             for kw in potential_kws:
                 test_list = [kw[:i] + kw[i + 1:] for i in range(len(kw))]
@@ -352,7 +347,8 @@ def run(keywords,
                         min_str += (kw[i])
                 result_min_str, num_results_min_str = has_censorship(min_str, cookies)
                 if result_min_str == "censored":  # minStr found properly
-                    print("the minimum phrase from '%s' is: '%s'" % (kw, min_str))
+                    if verbose=="all" or verbose=="some":
+                        print("the minimum phrase from '%s' is: '%s'" % (kw, min_str))
                     if insert:
                         insert_into_database(len(sqlite_to_df(sqlite_file)), min_str, date=date, result=result_min_str,
                                              source=r.source, num_results=num_results_min_str, notes=r.notes,

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -386,7 +386,11 @@ def run(keywords,
 
 
 def split_search_query(query, cookies, sleep=0, res_rtn=[], known_blocked=False):
-    """Recursively halves a query and returns portions with blocked keywords as a list of strings.
+    """
+    Recursively halves a query and returns portions with blocked keywords as a list of strings.
+    :param res_rtn: internal list holding found min keywords during recursive search, DO NOT SPECIFY.
+    :param known_blocked: set to True to skip a redundant first-check if you know your query is blocked.
+    :return: a list of one or more shortened keyword segments that trigger censorship
     """
     if len(query) <= 1:
         return [-1]

--- a/blockedonweibo/weibo.py
+++ b/blockedonweibo/weibo.py
@@ -319,7 +319,7 @@ def run(keywords,
             keyword_encoded = r.keyword
 
         if sqlite_file:
-            if r.Index < len(sqlite_to_df(sqlite_file).query("date=='%s' & source=='%s' & test_number==%s" % (date,source,test_number))) and continue_interruptions:
+            if r.Index < len(sqlite_to_df(sqlite_file).query("date=='%s' & source=='%s' & test_number==%s & is_canonical!=1" % (date,source,test_number))) and continue_interruptions:
                 continue
             if len(sqlite_to_df(sqlite_file).query(u"date=='%s' & source=='%s' & test_number==%s & keyword=='%s'" % (date,source,test_number,keyword_encoded)))>0 and continue_interruptions:
                 continue
@@ -386,7 +386,7 @@ def run(keywords,
         return results_df
 
 
-def split_search_query(query, cookies, sleep_secs=0, res_rtn=[], known_blocked=False):
+def split_search_query(query, cookies, sleep_secs=0, res_rtn=[], known_blocked=False, ):
     """
     Recursively halves a query and returns portions with blocked keywords as a list of strings.
     :param res_rtn: internal list holding found min keywords during recursive search, DO NOT SPECIFY.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='blockedonweibo',
-      version='0.1',
+      version='0.2',
       description='Testing if search keywords are censored on Sina Weibo',
       url='http://github.com/jasonqng/blocked-on-weibo',
       author='Jason Q. Ng',

--- a/update_db.py
+++ b/update_db.py
@@ -1,0 +1,55 @@
+import sqlite3
+import os, sys
+
+
+def find_db():
+    print("Finding database files...")
+    files = list(os.walk('.'))[0][2]
+    db_files = [file for file in files if ".db" in file or ".sqlite" in file]
+    if len(db_files)>0:
+        if len(db_files) == 1:
+            user_input = input("Is database file %s/%s? (y/N) " %(os.getcwd(), db_files[0]))
+            if user_input.lower() == 'y':
+                migrate_db(db_files[0])
+            else:
+                break_script()
+        else:
+            print("%d database files found in dir" %(len(db_files)))
+            for i in range(len(db_files)):
+                print("%d. %s" %(i+1, db_files[i]))
+            print("**************")
+            user_input = input("Which db file to upgrade? (Enter NUMBER) ")
+            if user_input.isdigit() and 0 < int(user_input) < len(db_files):
+                migrate_db(db_files[int(user_input) - 1])
+            else:
+                print("Invalid input.")
+                break_script()
+    else:
+        break_script()
+
+def migrate_db(db_location):
+    conn = sqlite3.connect(db_location)
+    c = conn.cursor()
+    c.execute('ALTER TABLE results RENAME TO resultsOld')
+    c.execute('''CREATE TABLE results (id INT, date DATE, datetime_logged DATETIME, test_number INT, keyword string, 
+        censored bool, no_results bool, reset bool, is_min bool, result string, source string, orig_keyword string, 
+        num_results INT, notes string, PRIMARY KEY(date,source,test_number,keyword))''')
+    c.execute('''INSERT INTO results (id, date, datetime_logged, test_number, keyword, censored, no_results, reset,
+        result, source, num_results, notes)
+                SELECT id, date, datetime_logged, test_number, keyword, censored, no_results, reset, result, source,
+                  num_results, notes FROM resultsOld
+    ''')
+    c.execute('DROP TABLE resultsOld')
+    conn.commit()
+    conn.close()
+    print("Updates completed successfully")
+    sys.exit()
+
+
+def break_script():
+    print("Please place this .py script in the same directory as your database file, then re-run. No changes were made")
+    sys.exit()
+
+
+if __name__ == "__main__":
+    find_db()

--- a/update_db.py
+++ b/update_db.py
@@ -3,6 +3,11 @@ import os, sys
 
 
 def find_db():
+    """
+    Search for database files in the current directory of this script file. Gets user input for confirmation of db file
+    if only 1 match; user input for selection if >1 db file present.
+    """
+
     print("Finding database files...")
     files = list(os.walk('.'))[0][2]
     db_files = [file for file in files if ".db" in file or ".sqlite" in file]
@@ -29,6 +34,11 @@ def find_db():
 
 
 def migrate_db(db_location):
+    """
+    sqlite3 code that conducts the actual database modifications. Renames the previous table, creates a new table
+    with new columns, moves contents of previous table over, then deletes the previous table.
+    :param db_location: filename of database file.
+    """
     conn = sqlite3.connect(db_location)
     c = conn.cursor()
     c.execute('ALTER TABLE results RENAME TO resultsOld')
@@ -48,6 +58,9 @@ def migrate_db(db_location):
 
 
 def break_script():
+    """
+    Print an error message to console before triggering sys.exit().
+    """
     print("Please place this .py script in the same directory as your database file, then re-run. No changes were made")
     sys.exit()
 

--- a/update_db.py
+++ b/update_db.py
@@ -8,7 +8,7 @@ def find_db():
     db_files = [file for file in files if ".db" in file or ".sqlite" in file]
     if len(db_files)>0:
         if len(db_files) == 1:
-            user_input = input("Is database file %s/%s? (y/N) " %(os.getcwd(), db_files[0]))
+            user_input = raw_input("Is database file %s/%s? (y/N) " %(os.getcwd(), db_files[0]))
             if user_input.lower() == 'y':
                 migrate_db(db_files[0])
             else:
@@ -18,7 +18,7 @@ def find_db():
             for i in range(len(db_files)):
                 print("%d. %s" %(i+1, db_files[i]))
             print("**************")
-            user_input = input("Which db file to upgrade? (Enter NUMBER) ")
+            user_input = raw_input("Which db file to upgrade? (Enter NUMBER) ")
             if user_input.isdigit() and 0 < int(user_input) < len(db_files):
                 migrate_db(db_files[int(user_input) - 1])
             else:
@@ -27,13 +27,14 @@ def find_db():
     else:
         break_script()
 
+
 def migrate_db(db_location):
     conn = sqlite3.connect(db_location)
     c = conn.cursor()
     c.execute('ALTER TABLE results RENAME TO resultsOld')
     c.execute('''CREATE TABLE results (id INT, date DATE, datetime_logged DATETIME, test_number INT, keyword string, 
-        censored bool, no_results bool, reset bool, is_min bool, result string, source string, orig_keyword string, 
-        num_results INT, notes string, PRIMARY KEY(date,source,test_number,keyword))''')
+        censored bool, no_results bool, reset bool, is_canonical bool, result string, source string, orig_keyword string, 
+        num_results INT, notes string, PRIMARY KEY(date,source,test_number,keyword,orig_keyword))''')
     c.execute('''INSERT INTO results (id, date, datetime_logged, test_number, keyword, censored, no_results, reset,
         result, source, num_results, notes)
                 SELECT id, date, datetime_logged, test_number, keyword, censored, no_results, reset, result, source,


### PR DESCRIPTION
Adds ability for researchers to determine canonical (minimum) search query keywords that trigger censorship. Implemented by recursively bisecting the search query to determine block(s) triggering censorship, then iterating through the shortened query removing one character at a time. Characters that when removed, cause censorship message to no longer show, are considered part of canonical censorship keyword. 

Enabled via parameter `get_canonical=True` (default=False) passed to `run()`. Helper function `split_search_query()` separately for recursive bisection. Changes have been tested.

Database table is modified to accommodate two new columns (`is_canonical bool` and `orig_keyword string`). Existing databases will need to be modified. A database updater script `update_db.py` is included.

README has been updated to include info on canonical keyword detection, migrating database, and tables in README now reflect new database table.  

Increments blocked-on-weibo project to v0.2